### PR TITLE
Fixes TypeError: Cannot read property 'some' of undefined.

### DIFF
--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -94,6 +94,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     const metadataFactoryMethod = classMutableNode.members.find(
       member =>
         ts.isMethodDeclaration(member) &&
+        member.modifiers &&
         member.modifiers.some(
           modifier => modifier.kind === ts.SyntaxKind.StaticKeyword
         ) &&


### PR DESCRIPTION
Fixes the bug: "TypeError: Cannot read property 'some' of undefined" when decorators @BeforeInsert, @AfterInsert etc. are placed in an entity.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information